### PR TITLE
adds ability to search for an email by person id, new object PersonId

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -18,6 +18,7 @@ function ClearbitClient (config) {
 
   this.Company = require('./enrichment/company').Company(this);
   this.Person = require('./enrichment/person').Person(this);
+  this.PersonId = require('./enrichment/person_by_id').PersonId(this);
   this.Enrichment = require('./enrichment').Enrichment(this);
   this.Discovery = require('./discovery').Discovery(this);
   this.Prospector = require('./prospector').Prospector(this);

--- a/src/enrichment/person_by_id.js
+++ b/src/enrichment/person_by_id.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var assert   = require('assert');
+var resource = require('../resource');
+
+exports.PersonId = resource.create('PersonId', {api: 'prospector', version: 1})
+  .extend({
+  },
+  {
+    find: function(options){
+      options = options || {};
+      assert(options.id, 'An ID must be provided');
+
+      return this.get('/people/' + options.id + '/email');
+    }
+  });


### PR DESCRIPTION
Quick hack to make the API endpoint of https://prospector.clearbit.com/v1/people/:id/email available in the client library. I find it more useful to query this endpoint by ID to get emails than to use the base Prospector endpoint with additional parameters.