### PR TITLE
Added headers to ClearbitError in order to pass back relevant data to caller

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -82,6 +82,7 @@ ClearbitClient.prototype.request = function (options) {
       throw _.extend(new this.ClearbitError(message), {
         type: body.error ? body.error.type : 'unknown',
         body: body,
+        headers: response.headers,
         statusCode: response.statusCode
       });
     }


### PR DESCRIPTION
This is useful when encountering a rate-limit error. If headers are passed back, retry-after can be used to delay for the appropriate amount of time before attempting a follow-up call.